### PR TITLE
Update get_slug_hexs.ts

### DIFF
--- a/src/utils/get_slug_hexs.ts
+++ b/src/utils/get_slug_hexs.ts
@@ -20,7 +20,7 @@ const primeCache = async () => {
       const res = await fetch(url, {cache: 'force-cache'})
       const json = await res.json()
       cache = {}
-      json.icons.forEach((icon: Icon) => {
+      json.forEach((icon: Icon) => {
         const iconSlug = getSlug({title: icon.title})
         cache![iconSlug] = {
           hex: addHash(icon.hex ?? fallback),


### PR DESCRIPTION
Remove icons because it doesn't exist in the json object.

### Description

This PR addresses issue #14 where icons were rendered in black color (`#000` or `#000000`). The following changes have been made:

1. **Code Adjustments:**
   - Removed `.icons` from `json.icons.forEach((icon: Icon) => {` to `json.forEach((icon: Icon) => {` in `src/utils/get_slug_hexs.ts` (line 23).

2. **Test Enhancements:**
   - Added additional checks in `fetch_simple_icons.test.ts` (lines 61-64) to ensure that not all icons have a fallback hex value of `#000` or `#000000`:
     ```javascript
     const hexValues = Object.values(icons.simpleIcons).map(icon => icon.hex)
     const allBlackHex = hexValues.every(hex => hex === '#000' || hex === '#000000')
     expect(allBlackHex).toBe(false)
     ```

### **Related Issue**
Closes #14
