### PR TITLE
Update fetch_simple_icons.test.ts

### DIFF
--- a/src/utils/fetch_simple_icons.test.ts
+++ b/src/utils/fetch_simple_icons.test.ts
@@ -58,6 +58,10 @@ describe('fetchIcons', () => {
       expect(icon.hex).toBeTruthy()
       expect(typeof icon.hex).toBe('string')
       expect(icon.hex).not.toBe('')
+
+      const hexValues = Object.values(icons.simpleIcons).map(icon => icon.hex)
+      const allBlackHex = hexValues.every(hex => hex === '#000' || hex === '#000000')
+      expect(allBlackHex).toBe(false)
     }
   })
 })


### PR DESCRIPTION
Add test to the updated line in fetch_simple_icons.ts.


### Description

This PR addresses issue #14 where icons were rendered in black color (`#000` or `#000000`). The following changes have been made:

1. **Code Adjustments:**
   - Removed `.icons` from `json.icons.forEach((icon: Icon) => {` to `json.forEach((icon: Icon) => {` in `src/utils/get_slug_hexs.ts` (line 23).

2. **Test Enhancements:**
   - Added additional checks in `fetch_simple_icons.test.ts` (lines 61-64) to ensure that not all icons have a fallback hex value of `#000` or `#000000`:
     ```javascript
     const hexValues = Object.values(icons.simpleIcons).map(icon => icon.hex)
     const allBlackHex = hexValues.every(hex => hex === '#000' || hex === '#000000')
     expect(allBlackHex).toBe(false)
     ```

### **Related Issue**
Closes #14
